### PR TITLE
libgdx-utils as 3rd party extension

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -17,4 +17,43 @@
            <html>null</html>
        </projects>
     </extension>
+    <extension>
+        <name>libgdx-utils</name>
+        <description>additional features and helper classes</description>
+        <package>net.dermetfan.gdx</package>
+        <version>0.10.0</version>
+        <compatibility>1.5.5</compatibility>
+        <website>http://dermetfan.net/libgdx-utils.php</website>
+        <projects>
+	        <core>
+		        <dependency>net.dermetfan.libgdx-utils:libgdx-utils</dependency>
+	        </core>
+	        <desktop></desktop>
+	        <android></android>
+	        <ios></ios>
+	        <html>
+		        <dependency>net.dermetfan.libgdx-utils:libgdx-utils:sources</dependency>
+	        </html>
+        </projects>
+    </extension>
+    <extension>
+        <name>libgdx-utils-box2d</name>
+        <description>additional features and helper classes for the official Box2D extension</description>
+        <package>net.dermetfan.gdx</package>
+        <version>0.10.0</version>
+        <compatibility>1.5.5</compatibility>
+        <website>http://dermetfan.net/libgdx-utils.php</website>
+        <projects>
+	        <core>
+		        <dependency>net.dermetfan.libgdx-utils:libgdx-utils-box2d</dependency>
+	        </core>
+	        <desktop></desktop>
+	        <android></android>
+	        <ios></ios>
+	        <html>
+		        <dependency>net.dermetfan.libgdx-utils:libgdx-utils-box2d:sources</dependency>
+		        <dependency>net.dermetfan.libgdx-utils:libgdx-utils-box2d-gwt:sources</dependency>
+	        </html>
+        </projects>
+    </extension>
 </extensions>


### PR DESCRIPTION
I'd like to add my little support library as a 3rd party extension to the gdx-setup app. Users already asked for this in the past before the XML configuration.

> Does your project aim to extend LibGDX with a specific goal in mind?

The goal is to offer additional features (like premade scene2d.ui widgets, the `TmxMapWriter`, `AnnotationAssetManager` or the [`PolygonRegionLoader`](https://github.com/libgdx/libgdx/pull/1602) which was merged into libGDX) and utility/helper classes to make game dev even more convenient. I'd let that count as specific enough even though it's rather broad.

> Is your project useful to LibGDX users?

I think so, it's catered towards them.

> Is your project well established?

Depends on what is well established enough. The repository currently has 9 forks and 46 watchers on Bitbucket. The only statistics I have are those from sonatype:
![chart](https://cloud.githubusercontent.com/assets/4956158/6659805/550ce006-cb8d-11e4-9bc3-175e20c62f51.png)

> Your project is well maintained

There was not a single month without commits since I started this project and it's usually compatible with the latest libGDX release.